### PR TITLE
Implemented Enumerator contract

### DIFF
--- a/examples/keywords.rb
+++ b/examples/keywords.rb
@@ -1,0 +1,24 @@
+require './lib/boyer_moore'
+
+transcript = "i was wondering if you require a credit check to open an account ? i'm not sure i would pass a credit check right now .".split(' ')
+
+phrases = {
+  ["credit", "check"]     => 1,
+  ["make", "appointment"] => 2,
+  ["now"]                 => 1
+}
+
+results = phrases.map do |phrase, count|
+  found_count = 0
+  found = BoyerMoore.search(transcript, phrase) { |index| (found_count += 1) >= count and break true } # stop searching as soon as we hit the count
+  [phrase, found]
+end
+
+
+
+results.each { |phrase, found| puts "#{phrase} => #{!!found}"}
+
+# =>
+# ["credit", "check"] => true
+# ["make", "appointment"] => false
+# ["now"] => true

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -1,22 +1,36 @@
 require_relative "./boyer_moore/version"
 
 module BoyerMoore
+  class Enumerator
+    def initialize(haystack, needle_string, starting_haystack_index = 0)
+      @haystack = haystack
+      @needle = Needle.new(needle_string)
+      @haystack_index = starting_haystack_index
+    end
+
+    def each
+      while @haystack_index <= @haystack.size - @needle.size
+        if skip_by = @needle.match_or_skip_by(@haystack, @haystack_index)
+          @haystack_index += skip_by
+        else
+          yield @haystack_index # Found a match here!
+          @haystack_index += @needle.size
+        end
+      end
+    end
+  end
+
   def self.find(haystack, needle_string)
     each(haystack, needle_string) { |index| return index }
     nil
   end
 
-  def self.each(haystack, needle_string)
-    needle = Needle.new(needle_string)
-
-    haystack_index = 0
-    while haystack_index <= haystack.size - needle.size
-      if skip_by = needle.match_or_skip_by(haystack, haystack_index)
-        haystack_index += skip_by
-      else
-        yield haystack_index # Found a match at haystack_index!
-        haystack_index += needle.size
-      end
+  def self.each(haystack, needle_string, starting_haystack_index = 0, &block)
+    enumerator = Enumerator.new(haystack, needle_string, starting_haystack_index)
+    if block
+      enumerator.each(&block)
+    else
+      enumerator.to_enum(:each)
     end
   end
 
@@ -80,7 +94,7 @@ module BoyerMoore
           prefix_reversed = self.class.prefix(@needle.reverse)
           result = []
           (0..@needle.size).each do |i|
-            result[i] = @needle.size - prefix_normal[@needle.size-1]
+            result[i] = @needle.size - prefix_normal[@needle.size - 1]
           end
           (0...@needle.size).each do |i|
             j = @needle.size - prefix_reversed[i]

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -1,6 +1,19 @@
 require_relative "./boyer_moore/version"
 
 module BoyerMoore
+
+  # Yields the index of each match of needle_string in haystack.
+  # If no block given, returns an Enumerator that does the same.
+  # Starts at starting_haystack_index (default = 0).
+  def self.search(haystack, needle_string, starting_haystack_index = 0, &block)
+    enumerator = Enumerator.new(haystack, needle_string, starting_haystack_index)
+    if block
+      enumerator.each(&block)
+    else
+      enumerator.to_enum(:each)
+    end
+  end
+
   class Enumerator
     def initialize(haystack, needle_string, starting_haystack_index = 0)
       @haystack = haystack
@@ -17,20 +30,6 @@ module BoyerMoore
           @haystack_index += @needle.size
         end
       end
-    end
-  end
-
-  def self.find(haystack, needle_string)
-    each(haystack, needle_string) { |index| return index }
-    nil
-  end
-
-  def self.each(haystack, needle_string, starting_haystack_index = 0, &block)
-    enumerator = Enumerator.new(haystack, needle_string, starting_haystack_index)
-    if block
-      enumerator.each(&block)
-    else
-      enumerator.to_enum(:each)
     end
   end
 

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -3,6 +3,7 @@ require_relative "./boyer_moore/version"
 module BoyerMoore
   def self.find(haystack, needle_string)
     each(haystack, needle_string) { |index| return index }
+    nil
   end
 
   def self.each(haystack, needle_string)

--- a/lib/boyer_moore.rb
+++ b/lib/boyer_moore.rb
@@ -1,7 +1,11 @@
 require_relative "./boyer_moore/version"
 
 module BoyerMoore
-  def self.search(haystack, needle_string)
+  def self.find(haystack, needle_string)
+    each(haystack, needle_string) { |index| return index }
+  end
+
+  def self.each(haystack, needle_string)
     needle = Needle.new(needle_string)
 
     haystack_index = 0
@@ -9,7 +13,8 @@ module BoyerMoore
       if skip_by = needle.match_or_skip_by(haystack, haystack_index)
         haystack_index += skip_by
       else
-        break haystack_index # Found a match at haystack_index!
+        yield haystack_index # Found a match at haystack_index!
+        haystack_index += needle.size
       end
     end
   end

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -18,7 +18,7 @@ describe BoyerMoore do
     end
   end
 
-  it "should find properly" do
+  it "should implement find" do
     expect(BoyerMoore.find("ANPANMAN", "ANP")).to eq 0
     expect(BoyerMoore.find("ANPANMAN", "ANPXX")).to eq nil
     expect(BoyerMoore.find("ANPANMAN", "MAN")).to eq 5
@@ -26,7 +26,7 @@ describe BoyerMoore do
     expect(BoyerMoore.find("foobar", "zar")).to eq nil
   end
 
-  it "should implement each properly" do
+  it "should implement each" do
     yielded = []
     BoyerMoore.each("ANPANMAN", "AN") { |index| yielded << index }
     expect(yielded).to eq [0, 3, 6]
@@ -42,6 +42,22 @@ describe BoyerMoore do
     yielded = []
     BoyerMoore.each("foobar", "zar") { |index| yielded << index }
     expect(yielded).to eq []
+  end
+
+  it "should implement each with a starting index" do
+    yielded = []
+    BoyerMoore.each("ANPANMAN", "AN", 0) { |index| yielded << index }
+    expect(yielded).to eq [0, 3, 6]
+    yielded = []
+    BoyerMoore.each("ANPANMAN", "AN", 1) { |index| yielded << index }
+    expect(yielded).to eq [3, 6]
+  end
+
+  it "should return an enumerator from each with no block" do
+    yielded = []
+    enumerator = BoyerMoore.each("ANPANMAN", "AN")
+    enumerator.each.with_index { |match_index, index| yielded[index] = match_index }
+    expect(yielded).to eq [0, 3, 6]
   end
 
   it "should match ruby's #index for basic strings" do

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -18,18 +18,36 @@ describe BoyerMoore do
     end
   end
 
-  it "should search properly" do
-    expect(BoyerMoore.search("ANPANMAN", "ANP")).to eq 0
-    expect(BoyerMoore.search("ANPANMAN", "ANPXX")).to eq nil 
-    expect(BoyerMoore.search("ANPANMAN", "MAN")).to eq 5
-    expect(BoyerMoore.search("foobar", "bar")).to eq 3
-    expect(BoyerMoore.search("foobar", "zar")).to eq nil 
+  it "should find properly" do
+    expect(BoyerMoore.find("ANPANMAN", "ANP")).to eq 0
+    expect(BoyerMoore.find("ANPANMAN", "ANPXX")).to eq nil
+    expect(BoyerMoore.find("ANPANMAN", "MAN")).to eq 5
+    expect(BoyerMoore.find("foobar", "bar")).to eq 3
+    expect(BoyerMoore.find("foobar", "zar")).to eq nil
+  end
+
+  it "should implement each properly" do
+    yielded = []
+    BoyerMoore.each("ANPANMAN", "AN") { |index| yielded << index }
+    expect(yielded).to eq [0, 3, 6]
+    yielded = []
+    BoyerMoore.each("ANANAN", "AN") { |index| yielded << index }
+    expect(yielded).to eq [0, 2, 4]
+    yielded = []
+    BoyerMoore.each("AAAB", "A") { |index| yielded << index }
+    expect(yielded).to eq [0, 1, 2]
+    yielded = []
+    BoyerMoore.each("ANPANMAN", "MAN") { |index| yielded << index }
+    expect(yielded).to eq [5]
+    yielded = []
+    BoyerMoore.each("foobar", "zar") { |index| yielded << index }
+    expect(yielded).to eq []
   end
 
   it "should match ruby's #index for basic strings" do
     needle = 'abcab'
     ['12abcabc', 'abcgghhhaabcabccccc', '123456789abc123abc', 'aabbcc'].each do |haystack|
-      expect(BoyerMoore.search(haystack, needle)).to eq haystack.index(needle)
+      expect(BoyerMoore.find(haystack, needle)).to eq haystack.index(needle)
     end
   end
   
@@ -40,12 +58,12 @@ describe BoyerMoore do
       %w[e f g] => nil,
       %w[m y _ d o g _ a b c] => 7
     }.each do |haystack, position|
-      expect(BoyerMoore.search(haystack, ['a', 'b', 'c'])).to eq position
+      expect(BoyerMoore.find(haystack, ['a', 'b', 'c'])).to eq position
     end
   end
 
   it "should match in the middle of a string" do
-    expect(BoyerMoore.search("xxxfoobarbazxxx".split(''), "foobar".split(''))).to eq 3
+    expect(BoyerMoore.find("xxxfoobarbazxxx".split(''), "foobar".split(''))).to eq 3
   end
 
   it "should match words" do
@@ -55,7 +73,7 @@ describe BoyerMoore do
       ["put", "foo", "bar", "bar"] => 1,
       ["put", "foo", "bar", "foo", "bar"] => 1
     }.each do |haystack, position|
-      expect(BoyerMoore.search(haystack, ["foo", "bar"])).to eq position
+      expect(BoyerMoore.find(haystack, ["foo", "bar"])).to eq position
     end
   end
 end

--- a/spec/boyer_moore_spec.rb
+++ b/spec/boyer_moore_spec.rb
@@ -18,44 +18,46 @@ describe BoyerMoore do
     end
   end
 
-  it "should implement find" do
-    expect(BoyerMoore.find("ANPANMAN", "ANP")).to eq 0
-    expect(BoyerMoore.find("ANPANMAN", "ANPXX")).to eq nil
-    expect(BoyerMoore.find("ANPANMAN", "MAN")).to eq 5
-    expect(BoyerMoore.find("foobar", "bar")).to eq 3
-    expect(BoyerMoore.find("foobar", "zar")).to eq nil
-  end
-
-  it "should implement each" do
+  it "should implement search" do
     yielded = []
-    BoyerMoore.each("ANPANMAN", "AN") { |index| yielded << index }
+    BoyerMoore.search("ANPANMAN", "AN") { |index| yielded << index }
     expect(yielded).to eq [0, 3, 6]
     yielded = []
-    BoyerMoore.each("ANANAN", "AN") { |index| yielded << index }
+    BoyerMoore.search("ANANAN", "AN") { |index| yielded << index }
     expect(yielded).to eq [0, 2, 4]
     yielded = []
-    BoyerMoore.each("AAAB", "A") { |index| yielded << index }
+    BoyerMoore.search("AAAB", "A") { |index| yielded << index }
     expect(yielded).to eq [0, 1, 2]
     yielded = []
-    BoyerMoore.each("ANPANMAN", "MAN") { |index| yielded << index }
+    BoyerMoore.search("ANPANMAN", "MAN") { |index| yielded << index }
     expect(yielded).to eq [5]
     yielded = []
-    BoyerMoore.each("foobar", "zar") { |index| yielded << index }
+    BoyerMoore.search("foobar", "zar") { |index| yielded << index }
     expect(yielded).to eq []
   end
 
-  it "should implement each with a starting index" do
+  it "should implement search with a starting index" do
     yielded = []
-    BoyerMoore.each("ANPANMAN", "AN", 0) { |index| yielded << index }
+    BoyerMoore.search("ANPANMAN", "AN", 0) { |index| yielded << index }
     expect(yielded).to eq [0, 3, 6]
     yielded = []
-    BoyerMoore.each("ANPANMAN", "AN", 1) { |index| yielded << index }
+    BoyerMoore.search("ANPANMAN", "AN", 1) { |index| yielded << index }
     expect(yielded).to eq [3, 6]
+  end
+
+  it "should implement search to work with first" do
+    expect(BoyerMoore.search("ANPANMAN", "ANP").first).to eq 0
+    expect(BoyerMoore.search("ANPANMAN", "ANPXX").first).to eq nil
+  end
+
+  it "should implement search to work with first with a starting index" do
+    expect(BoyerMoore.search("ANPANPAN", "ANP", 0).first).to eq 0
+    expect(BoyerMoore.search("ANPANPAN", "ANP", 1).first).to eq 3
   end
 
   it "should return an enumerator from each with no block" do
     yielded = []
-    enumerator = BoyerMoore.each("ANPANMAN", "AN")
+    enumerator = BoyerMoore.search("ANPANMAN", "AN")
     enumerator.each.with_index { |match_index, index| yielded[index] = match_index }
     expect(yielded).to eq [0, 3, 6]
   end
@@ -63,7 +65,7 @@ describe BoyerMoore do
   it "should match ruby's #index for basic strings" do
     needle = 'abcab'
     ['12abcabc', 'abcgghhhaabcabccccc', '123456789abc123abc', 'aabbcc'].each do |haystack|
-      expect(BoyerMoore.find(haystack, needle)).to eq haystack.index(needle)
+      expect(BoyerMoore.search(haystack, needle).first).to eq haystack.index(needle)
     end
   end
   
@@ -74,12 +76,12 @@ describe BoyerMoore do
       %w[e f g] => nil,
       %w[m y _ d o g _ a b c] => 7
     }.each do |haystack, position|
-      expect(BoyerMoore.find(haystack, ['a', 'b', 'c'])).to eq position
+      expect(BoyerMoore.search(haystack, ['a', 'b', 'c']).first).to eq position
     end
   end
 
   it "should match in the middle of a string" do
-    expect(BoyerMoore.find("xxxfoobarbazxxx".split(''), "foobar".split(''))).to eq 3
+    expect(BoyerMoore.search("xxxfoobarbazxxx".split(''), "foobar".split('')).first).to eq 3
   end
 
   it "should match words" do
@@ -89,7 +91,7 @@ describe BoyerMoore do
       ["put", "foo", "bar", "bar"] => 1,
       ["put", "foo", "bar", "foo", "bar"] => 1
     }.each do |haystack, position|
-      expect(BoyerMoore.find(haystack, ["foo", "bar"])).to eq position
+      expect(BoyerMoore.search(haystack, ["foo", "bar"]).first).to eq position
     end
   end
 end


### PR DESCRIPTION
- Put the public name back to `search`. Documented its contract.
- Implemented the Enumerator contract.
- Now that Enumerator is there, `search(...).first` does what `find` did... so removed `find`. :)
- Added an optional index in case the caller wants to start the search midway into the haystack.
